### PR TITLE
[maintenance] workflows: 定期実行スケジュールを無効化

### DIFF
--- a/.github/workflows/backlog-candidate-propose.yml
+++ b/.github/workflows/backlog-candidate-propose.yml
@@ -1,8 +1,8 @@
 name: Backlog Candidate Propose
 
 on:
-  schedule:
-    - cron: '0 */3 * * *'  # 3時間ごと
+  # schedule:
+  #   - cron: '0 */3 * * *'  # 3時間ごと
   workflow_dispatch: {}      # 手動実行も可能
 
 jobs:

--- a/.github/workflows/daily-triage.yml
+++ b/.github/workflows/daily-triage.yml
@@ -1,9 +1,9 @@
 name: Daily Triage
 
 on:
-  schedule:
-    # 毎日 UTC 0:00 に実行
-    - cron: '0 0 * * *'
+  # schedule:
+  #   # 毎日 UTC 0:00 に実行
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
     # 手動実行も可能（テスト用）
 


### PR DESCRIPTION
- daily-triage.yml: schedule トリガーをコメントアウト
- backlog-candidate-propose.yml: schedule トリガーをコメントアウト
- workflow_dispatch（手動実行）は維持

https://claude.ai/code/session_01PwT8WhsrxN4Akcq2VWiSAw