### PR TITLE
[maintenance] gha-skills: sandbox mkdir ブロック対策（Write ツール使用明記・リトライ禁止）

### DIFF
--- a/.claude/skills/gha-close/SKILL.md
+++ b/.claude/skills/gha-close/SKILL.md
@@ -21,6 +21,7 @@ user-invocable: false
    - `04_work_report.md` の「作業中の知見」と `06_eval_report.md` の「評価中の知見」を確認
    - ルール化候補は該当ファイルへの反映を検討
    - 次施策候補は `inbox/` にファイルを作成
+   - 外部リポジトリの知見は `refs/<リポ名>/knowledge.md` に Write ツールで書き込む（Write ツールは親ディレクトリを自動作成するため mkdir は不要）
 3. 施策ディレクトリを `_archive/` に移動する:
    ```bash
    git mv <施策ディレクトリ> sessions/initiatives/_archive/<施策名>/
@@ -48,6 +49,8 @@ user-invocable: false
 - 対象リポジトリは dev-process-improvement のみ
 - コミットメッセージ規約（`.claude/rules/commit-message.md`）に従う
 - コミットメッセージは `[L1] <施策名>: クローズ（アーカイブ移動・知見ルーティング）` の形式で
+- ファイル作成は Write ツールを使用する（`Bash(mkdir *)` は sandbox でブロックされる）
+- ツール使用が sandbox にブロックされた場合、同じ操作のリトライは行わず代替手段に切り替える
 
 ---
 **作成日**: 2026-03-15

--- a/.claude/skills/gha-execute/SKILL.md
+++ b/.claude/skills/gha-execute/SKILL.md
@@ -60,6 +60,8 @@ user-invocable: false
 - 対象リポジトリは dev-process-improvement のみ
 - コミットメッセージ規約（`.claude/rules/commit-message.md`）に従う
 - コミットメッセージは `[L1] <施策名>: 実行フェーズ` の形式で
+- ファイル作成は Write ツールを使用する（`Bash(mkdir *)` は sandbox でブロックされる）
+- ツール使用が sandbox にブロックされた場合、同じ操作のリトライは行わず代替手段に切り替える
 
 ---
 **作成日**: 2026-03-15

--- a/refs/claude-code-action/knowledge.md
+++ b/refs/claude-code-action/knowledge.md
@@ -33,6 +33,7 @@
 | 19 | gha-initiative-skills-separation | 2026-03-15 | ワークフロー検証 | `claude-code-action` の OIDC トークン交換時、ワークフローファイルが default branch（main）と一致しているか検証される。ブランチ上でワークフロー YAML を変更した場合、マージ前のテスト実行は失敗する（`Workflow validation failed`） |
 | 20 | gha-initiative-skills-separation | 2026-03-15 | デバッグ | `show_full_output: true` を設定すると、Claude の各ターンの thinking・tool_use・tool_result が GHA ログに出力され、permission denial やインジェクション誤検知の原因特定に有用 |
 | 21 | gha-initiative-skills-separation | 2026-03-15 | ディスパッチャー | `@ai-task /reject` の後に改行してフィードバックを書くと、ディスパッチャーの `sed` パースが1行目の空文字列のみを抽出し、フィードバックが消失する。`echo "args=..."` も1行しか `GITHUB_OUTPUT` に書けない。修正: sed で複数行対応 + HEREDOC 形式で出力 |
+| 22 | harness-engineering-brushup | 2026-03-15 | ターン消費 | gha-close の知見ルーティングで `mkdir -p refs/ai-driven-dev-patterns` が sandbox にブロックされ 4回リトライ→max-turns(30)到達。Write ツール使用を SKILL.md に明記して解決。#14/#15 の知見がスキルに未反映だったことが原因 |
 
 ## 知見の詳細
 


### PR DESCRIPTION
- gha-close SKILL.md: 知見ルーティングで Write ツール使用を明記、sandbox ブロック時のリトライ禁止を制約に追加
- gha-execute SKILL.md: 予防的に同じ制約を追加
- refs/claude-code-action/knowledge.md: #22 としてインシデント記録（mkdir 4回リトライ→max-turns到達）

https://claude.ai/code/session_012MM8ieQGp3YtqCRysUnUYV